### PR TITLE
Implement Implicit Login

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -92,7 +92,12 @@ pub async fn start_server(pool: SqlitePool, args: &Args) -> Result<()> {
             origin_regex.is_match(origin.to_str().unwrap_or_default())
         }))
         .allow_methods(cors::Any)
-        .allow_headers(cors::Any)
+        .allow_headers(vec![
+            HeaderName::from_static("authorization"),
+            HeaderName::from_static("content-type"),
+            HeaderName::from_static("accept")
+            ]
+        )
         .expose_headers(vec![HeaderName::from_static("authorization")]);
 
     let api = Router::new()

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -92,13 +92,13 @@ pub async fn start_server(pool: SqlitePool, args: &Args) -> Result<()> {
             origin_regex.is_match(origin.to_str().unwrap_or_default())
         }))
         .allow_methods(cors::Any)
-        .allow_headers(vec![
+        .allow_headers([
             HeaderName::from_static("authorization"),
             HeaderName::from_static("content-type"),
             HeaderName::from_static("accept")
             ]
         )
-        .expose_headers(vec![HeaderName::from_static("authorization")]);
+        .expose_headers([HeaderName::from_static("authorization")]);
 
     let api = Router::new()
         .route("/register", post(create_user))

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -265,8 +265,8 @@ pub async fn get_user_from_token(
     JwtAuth(user): JwtAuth<UserToken>,
 ) -> Result<Response, AppError> {
     let Some(user) = sqlx::query_as!(
-        SessionUser,
-        "SELECT id, username, email, first_name, last_name FROM users WHERE id = ?",
+        PublicUser,
+        "SELECT id, username, first_name, last_name FROM users WHERE id = ?",
         user.id
     )
     .fetch_optional(&pool)

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,4 +1,5 @@
 # Logs
+.env
 logs
 *.log
 npm-debug.log*

--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>AI Health Assistant</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,9 +14,12 @@ function App() {
           <h1 className=" text-6xl text-offwhite">
             AI Personal Health Assistant
           </h1>
-          <h1 className=" text-offwhite text-3xl">
-            Implicit User: {user.username} {user.firstName}
-          </h1>
+          {user && (
+            <h1 className=" text-offwhite text-3xl underline">
+              Welcome back, {user.username}
+            </h1>
+          )}
+
           <p className=" text-surface75 text-xl">
             An AI assistant that monitors your health and provides suggestions
             for improvement.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,9 +2,11 @@ import { Link } from "react-router-dom";
 import "./App.css";
 import Background from "./components/Background";
 import useImplicitLogin from "./store/hooks/useImplicitLogin";
+import useUserStore from "./store/hooks/useUserStore";
 
 function App() {
-  const implicitUser = useImplicitLogin();
+  useImplicitLogin();
+  const user = useUserStore();
   return (
     <>
       <Background color="black" className="pt-16">
@@ -13,7 +15,7 @@ function App() {
             AI Personal Health Assistant
           </h1>
           <h1 className=" text-offwhite text-3xl">
-            Implicit User: {implicitUser}
+            Implicit User: {user.username} {user.firstName}
           </h1>
           <p className=" text-surface75 text-xl">
             An AI assistant that monitors your health and provides suggestions

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,9 +14,9 @@ function App() {
           <h1 className=" text-6xl text-offwhite">
             AI Personal Health Assistant
           </h1>
-          {user && (
+          {user.id !== -1 && (
             <h1 className=" text-offwhite text-3xl underline">
-              Welcome back, {user.username}
+              Welcome back, {user.username} with email {user.email}
             </h1>
           )}
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,19 @@
 import { Link } from "react-router-dom";
 import "./App.css";
 import Background from "./components/Background";
+import useImplicitLogin from "./store/hooks/useImplicitLogin";
 
 function App() {
+  const implicitUser = useImplicitLogin();
   return (
     <>
       <Background color="black" className="pt-16">
         <div className="w-full flex flex-col justify-center items-center gap-4">
           <h1 className=" text-6xl text-offwhite">
             AI Personal Health Assistant
+          </h1>
+          <h1 className=" text-offwhite text-3xl">
+            Implicit User: {implicitUser}
           </h1>
           <p className=" text-surface75 text-xl">
             An AI assistant that monitors your health and provides suggestions

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -34,6 +34,8 @@ export default function Login() {
       });
 
       const result = await response.json();
+      console.log(JSON.stringify(result));
+
       if (response.ok) {
         setResponseMessage(result.message);
         setError(false);

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -34,7 +34,6 @@ export default function Login() {
       });
 
       const result = await response.json();
-      console.log(JSON.stringify(result));
 
       if (response.ok) {
         setResponseMessage(result.message);

--- a/client/src/components/Register.tsx
+++ b/client/src/components/Register.tsx
@@ -45,7 +45,8 @@ export default function Register() {
       } else {
         setError(false);
         setResponseMessage(result.message);
-        dispatch(updateUser(user));
+        const { password, ...passwordlessUser } = user;
+        dispatch(updateUser(passwordlessUser));
       }
     } catch (error) {
       setResponseMessage("An error occurred. Please try again later.");

--- a/client/src/components/Register.tsx
+++ b/client/src/components/Register.tsx
@@ -45,8 +45,6 @@ export default function Register() {
       } else {
         setError(false);
         setResponseMessage(result.message);
-        const { password, ...passwordlessUser } = user;
-        dispatch(updateUser(passwordlessUser));
       }
     } catch (error) {
       setResponseMessage("An error occurred. Please try again later.");

--- a/client/src/schemas.ts
+++ b/client/src/schemas.ts
@@ -1,9 +1,23 @@
-import {z} from "zod"
+import { z } from "zod";
 
 export const registerBodySchema = z.object({
-    firstName: z.string().min(1),
-    lastName: z.string().min(1),
-    username: z.string().min(1),
-    email: z.string().min(1),
-    password: z.string().min(1)
-})
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  username: z.string().min(1),
+  email: z.string().min(1),
+  password: z.string().min(1),
+});
+
+export const publicUserSchema =  z.object({
+    id: z.number(),
+    firstName: z.string(),
+    lastName: z.string(),
+    username: z.string(),
+  });
+
+export const implicitLoginSchema = publicUserSchema
+
+export const loginResponseSchema = z.object({
+  message: z.string(),
+  user: publicUserSchema,
+});

--- a/client/src/schemas.ts
+++ b/client/src/schemas.ts
@@ -8,16 +8,17 @@ export const registerBodySchema = z.object({
   password: z.string().min(1),
 });
 
-export const publicUserSchema =  z.object({
+export const sessionUserSchema =  z.object({
     id: z.number(),
+    email: z.string(),
     firstName: z.string(),
     lastName: z.string(),
     username: z.string(),
   });
 
-export const implicitLoginSchema = publicUserSchema
+export const implicitLoginSchema = sessionUserSchema
 
 export const loginResponseSchema = z.object({
   message: z.string(),
-  user: publicUserSchema,
+  user: sessionUserSchema,
 });

--- a/client/src/store/hooks/useImplicitLogin.tsx
+++ b/client/src/store/hooks/useImplicitLogin.tsx
@@ -1,0 +1,14 @@
+import { loginImplicitly } from "../../utils/utils";
+
+export default function useImplicitLogin() {
+  let user = "";
+  loginImplicitly()
+    .then((result) => {
+      if (!result) return;
+      user = result;
+    })
+    .catch((err) => {
+      console.log(`Implicit Login Error: ${err}`);
+    });
+  return user;
+}

--- a/client/src/store/hooks/useImplicitLogin.tsx
+++ b/client/src/store/hooks/useImplicitLogin.tsx
@@ -1,14 +1,23 @@
+import { useEffect } from "react";
 import { loginImplicitly } from "../../utils/utils";
+import useAppDispatch from "./useAppDispatch";
+import { updateUser } from "../userSlice";
 
 export default function useImplicitLogin() {
-  let user = "";
-  loginImplicitly()
-    .then((result) => {
-      if (!result) return;
-      user = result;
-    })
-    .catch((err) => {
-      console.log(`Implicit Login Error: ${err}`);
-    });
-  return user;
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const login = async () => {
+      try {
+        const user = await loginImplicitly();
+        if (user) {
+          dispatch(updateUser(user));
+        }
+      } catch (err) {
+        console.log(`Implicit Login Error: ${err}`);
+      }
+    };
+
+    login();
+  }, []);
 }

--- a/client/src/store/userSlice.ts
+++ b/client/src/store/userSlice.ts
@@ -1,8 +1,9 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { PublicUserState } from "../types";
+import { SessionUser } from "../types";
 
-const initialState: PublicUserState = {
+const initialState: SessionUser = {
     id: -1,
+    email: "",
     firstName: "",
     lastName: "",
     username: "",
@@ -12,7 +13,7 @@ const userSlice = createSlice({
     name: "user",
     initialState,
     reducers: {
-        updateUser(state, action: PayloadAction<PublicUserState>){
+        updateUser(state, action: PayloadAction<SessionUser>){
             return {...state, ...action.payload}
         }
     }

--- a/client/src/store/userSlice.ts
+++ b/client/src/store/userSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { UserState } from "../types";
+import { PublicUserState } from "../types";
 
-const initialState: UserState = {
-    email: "",
+const initialState: PublicUserState = {
+    id: -1,
     firstName: "",
     lastName: "",
     username: "",
@@ -12,7 +12,7 @@ const userSlice = createSlice({
     name: "user",
     initialState,
     reducers: {
-        updateUser(state, action: PayloadAction<UserState>){
+        updateUser(state, action: PayloadAction<PublicUserState>){
             return {...state, ...action.payload}
         }
     }

--- a/client/src/store/userSlice.ts
+++ b/client/src/store/userSlice.ts
@@ -1,19 +1,18 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { RegisterBody } from "../types";
+import { UserState } from "../types";
 
-const initialState: RegisterBody = {
+const initialState: UserState = {
     email: "",
     firstName: "",
     lastName: "",
     username: "",
-    password: ""
 }
 
 const userSlice = createSlice({
     name: "user",
     initialState,
     reducers: {
-        updateUser(state, action: PayloadAction<RegisterBody>){
+        updateUser(state, action: PayloadAction<UserState>){
             return {...state, ...action.payload}
         }
     }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -17,15 +17,16 @@ export type ServerResponse = {
 
 export type LoginResponse = {
     message: string,
-    user: PublicUserState
+    user: SessionUser
 }
 
 export type ErrorResponse = {
     errorMessage: string
 }
 
-export type PublicUserState = {
-    id: number
+export type SessionUser = {
+    id: number,
+    email: string,
     firstName: string,
     lastName: string
     username: string,

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -18,3 +18,10 @@ export type ServerResponse = {
 export type ErrorResponse = {
     errorMessage: string
 }
+
+export type UserState = {
+    firstName: string,
+    lastName: string
+    username: string,
+    email: string,
+}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -15,13 +15,18 @@ export type ServerResponse = {
     message: string
 }
 
+export type LoginResponse = {
+    message: string,
+    user: PublicUserState
+}
+
 export type ErrorResponse = {
     errorMessage: string
 }
 
-export type UserState = {
+export type PublicUserState = {
+    id: number
     firstName: string,
     lastName: string
     username: string,
-    email: string,
 }

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -18,6 +18,28 @@ export async function RegisterUser(
   return result;
 }
 
+export const loginImplicitly = async (): Promise<string | undefined> => {
+  const jwt = getJwt()
+  if(!jwt) return
+  const response = await fetch("http://localhost:3000/api/login", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "authorization": `Bearer ${jwt}`
+    },
+  })
+  const data = await response.json()
+  if(!response.ok) {
+    console.log("Implicit Login Error");
+    return
+  }
+  console.log("Successful Implicit Login?");
+  
+  console.log(data);
+  return "fake user implicit login"
+  
+}
+
 const mainColors = [
   "bg-main-green",
   "bg-orangey",
@@ -42,4 +64,10 @@ export const getJwtFromResponseHeader = (response: Response) => {
 
 export const saveJwtToLocalStorage = (jwt: string) => {
   localStorage.setItem("token", jwt)
+}
+
+export const getJwt = (): string => {
+  const jwt = localStorage.getItem("token")
+  if(!jwt) return ""
+  return jwt
 }

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -1,4 +1,5 @@
-import { RegisterBody, ServerResponse, ErrorResponse } from "../types";
+import {  implicitLoginSchema,  } from "../schemas";
+import { RegisterBody, ServerResponse, ErrorResponse, PublicUserState } from "../types";
 
 export async function RegisterUser(
   user: RegisterBody
@@ -18,7 +19,7 @@ export async function RegisterUser(
   return result;
 }
 
-export const loginImplicitly = async (): Promise<string | undefined> => {
+export const loginImplicitly = async (): Promise<PublicUserState | undefined> => {
   const jwt = getJwt()
   if(!jwt) return
   const response = await fetch("http://localhost:3000/api/login", {
@@ -33,10 +34,14 @@ export const loginImplicitly = async (): Promise<string | undefined> => {
     console.log("Implicit Login Error");
     return
   }
-  console.log("Successful Implicit Login?");
+  const parsedData = implicitLoginSchema.safeParse(data)
+  if(parsedData.error) {
+    console.log(parsedData.error);
+    return
+  }
+  console.log(`Successful Implicit Login: User ${parsedData.data.username}`);
   
-  console.log(data);
-  return "fake user implicit login"
+  return parsedData.data
   
 }
 

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -1,5 +1,5 @@
 import {  implicitLoginSchema,  } from "../schemas";
-import { RegisterBody, ServerResponse, ErrorResponse, PublicUserState } from "../types";
+import { RegisterBody, ServerResponse, ErrorResponse, SessionUser } from "../types";
 
 export async function RegisterUser(
   user: RegisterBody
@@ -19,7 +19,7 @@ export async function RegisterUser(
   return result;
 }
 
-export const loginImplicitly = async (): Promise<PublicUserState | undefined> => {
+export const loginImplicitly = async (): Promise<SessionUser | undefined> => {
   const jwt = getJwt()
   if(!jwt) return
   const response = await fetch("http://localhost:3000/api/login", {


### PR DESCRIPTION
## Rust Changes
- Explicitly expose the "authorization" header
- Changed `get_user_from_token` to return the `PublicUser` instead of `SessionUser`. 
  - The only difference between these types is that SessionUser has email property, PublicUser does not
  - I did this because I think that the normal login route and implicit route should return the same user struct 
  - Not married to the idea, willing to change